### PR TITLE
Add LiveReload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ group :development do
   gem 'guard'
   # Guard plugin for RSpec
   gem 'guard-rspec'
+  # Guard plugin to reload browser
+  gem 'guard-livereload', '~> 2.5', require: false
   # Better Errors gives us more options when debugging errors
   gem 'better_errors'
   # More features for better_errors

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ group :development do
   gem 'guard-rspec'
   # Guard plugin to reload browser
   gem 'guard-livereload', '~> 2.5', require: false
+  # Injects livereload.js
+  gem 'rack-livereload'
   # Better Errors gives us more options when debugging errors
   gem 'better_errors'
   # More features for better_errors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,11 @@ GEM
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    eventmachine (1.2.3)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -112,11 +116,17 @@ GEM
       shellany (~> 0.0)
       thor (>= 0.18.1)
     guard-compat (1.2.1)
+    guard-livereload (2.5.2)
+      em-websocket (~> 0.5)
+      guard (~> 2.8)
+      guard-compat (~> 1.0)
+      multi_json (~> 1.8)
     guard-rspec (4.7.3)
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.1)
+    http_parser.rb (0.6.0)
     i18n (0.7.0)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -306,6 +316,7 @@ DEPENDENCIES
   font-awesome-rails
   fuubar
   guard
+  guard-livereload (~> 2.5)
   guard-rspec
   jbuilder (~> 2.5)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     public_suffix (2.0.4)
     puma (3.6.2)
     rack (2.0.1)
+    rack-livereload (0.3.16)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.0.1)
@@ -324,6 +326,7 @@ DEPENDENCIES
   phantomjs
   poltergeist
   puma (~> 3.0)
+  rack-livereload
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-assets-tether (>= 1.1.0)!
   rspec-rails

--- a/Guardfile
+++ b/Guardfile
@@ -68,3 +68,42 @@ guard :rspec, cmd: "bundle exec rspec" do
     Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
   end
 end
+
+guard 'livereload' do
+  extensions = {
+    css: :css,
+    scss: :css,
+    sass: :css,
+    js: :js,
+    coffee: :js,
+    html: :html,
+    png: :png,
+    gif: :gif,
+    jpg: :jpg,
+    jpeg: :jpeg,
+    # less: :less, # uncomment if you want LESS stylesheets done in browser
+  }
+
+  rails_view_exts = %w(erb haml slim)
+
+  # file types LiveReload may optimize refresh for
+  compiled_exts = extensions.values.uniq
+  watch(%r{public/.+\.(#{compiled_exts * '|'})})
+
+  extensions.each do |ext, type|
+    watch(%r{
+          (?:app|vendor)
+          (?:/assets/\w+/(?<path>[^.]+) # path+base without extension
+           (?<ext>\.#{ext})) # matching extension (must be first encountered)
+          (?:\.\w+|$) # other extensions
+          }x) do |m|
+      path = m[1]
+      "/assets/#{path}.#{type}"
+    end
+  end
+
+  # file needing a full reload of the page anyway
+  watch(%r{app/views/.+\.(#{rails_view_exts * '|'})$})
+  watch(%r{app/helpers/.+\.rb})
+  watch(%r{config/locales/.+\.yml})
+end

--- a/Guardfile
+++ b/Guardfile
@@ -69,7 +69,7 @@ guard :rspec, cmd: "bundle exec rspec" do
   end
 end
 
-guard 'livereload' do
+guard :livereload do
   extensions = {
     css: :css,
     scss: :css,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Inject livereload.js into HTML pages
+  config.middleware.insert_before ActionDispatch::DebugExceptions, Rack::LiveReload, no_swf: true
 end


### PR DESCRIPTION
LiveReload updates the browser when files change.

`guard-livereload` pulls in the `eventmachine` dependency but it claims to work well on Windows.